### PR TITLE
Add keep_backup_amount options

### DIFF
--- a/src/Ploi/Resources/DatabaseBackup.php
+++ b/src/Ploi/Resources/DatabaseBackup.php
@@ -58,7 +58,8 @@ class DatabaseBackup extends Resource
         string $type,
         string $table_exclusions = null,
         string $locations = null,
-        string $path = null
+        string $path = null,
+        int $keep_backup_amount = null
     ): Response
     {
         // Remove the id
@@ -71,7 +72,8 @@ class DatabaseBackup extends Resource
                 'type' => $type,
                 'table_exclusions' => $table_exclusions,
                 'locations' => $locations,
-                'path' => $path
+                'path' => $path,
+                'keep_backup_amount' => $keep_backup_amount
             ]),
         ];
 


### PR DESCRIPTION
Add "keep_backup_amount" option for Create backup API endpoint ([https://developers.ploi.io/34-database-backups/100-create-backup](https://developers.ploi.io/34-database-backups/100-create-backup))